### PR TITLE
backend: fix incorrect references to binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ location ^~ /admin
 ## CLI help
 ```shell
 Usage:
-  rustdesk-api-server [command]
+  rustdesk-api-server-pro [command]
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
@@ -202,9 +202,9 @@ Available Commands:
   user        User management
 
 Flags:
-  -h, --help   help for rustdesk-api-server
+  -h, --help   help for rustdesk-api-server-pro
 
-Use "rustdesk-api-server [command] --help" for more information about a command.
+Use "rustdesk-api-server-pro [command] --help" for more information about a command.
 ```
 
 ## Follow-up plan

--- a/README_CN.md
+++ b/README_CN.md
@@ -187,7 +187,7 @@ location ^~ /admin
 ## CLI命令行
 ```shell
 Usage:
-  rustdesk-api-server [command]
+  rustdesk-api-server-pro [command]
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
@@ -198,9 +198,9 @@ Available Commands:
   user        User management
 
 Flags:
-  -h, --help   help for rustdesk-api-server
+  -h, --help   help for rustdesk-api-server-pro
 
-Use "rustdesk-api-server [command] --help" for more information about a command.
+Use "rustdesk-api-server-pro [command] --help" for more information about a command.
 ```
 
 ## 后续计划

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -5,5 +5,5 @@ import (
 )
 
 var RootCmd = &cobra.Command{
-	Use: "rustdesk-api-server [command]",
+	Use: "rustdesk-api-server-pro [command]",
 }


### PR DESCRIPTION
There are some references to `rustdesk-api-server` on the binary's help and documentation instead of `rustdesk-api-server-pro`.

This PR fixes that.