### PR TITLE
soybean-admin: move front-end to be served under /admin

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,7 +38,7 @@ jobs:
           go env -w GOOS=${{matrix.os}}
           go env -w GOARCH=${{matrix.arch}}
           go build -C backend -o ../build/
-          cd soybean-admin && pnpm build 
+          cd soybean-admin && pnpm build --outDir dist/admin
           cd .. && cp -R soybean-admin/dist build/
           cp backend/server.yaml build/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /frontend
 COPY ./soybean-admin .
 RUN rm -rf node_modules
 RUN npm install -g pnpm
-RUN pnpm i && pnpm build
+RUN pnpm i && pnpm build --outDir dist/admin
 
 FROM alpine:3.20.3
 ENV ADMIN_USER=

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ frontend_dist=${frontend}/dist
 
 build: clean
 	go build -C backend -o ../${main_output}/
-	cd ${frontend} && pnpm build && cp -R dist ${main_output}/
+	cd ${frontend} && pnpm build --outDir dist/admin && cp -R dist ${main_output}/
 
 clean:
 	rm -rf ${main_output}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd backend && go build
 
 3. Build the frontend
 ```shell
-cd soybean-admin && pnpm i && pnpm build
+cd soybean-admin && pnpm i && pnpm build --outDir dist/admin
 ```
 
 ### Run
@@ -153,30 +153,14 @@ Reverse Proxy Configuration, you need to configure reverse proxy in `nginx` or o
 
 Here's my backend reverse proxy configuration for you to refer to:
 ```nginx
-#PROXY-START /api for rustdesk client
-location ^~ /api
+#PROXY-START
+location ~ ^/(api|admin)
 {
     proxy_pass http://127.0.0.1:8080;
-    proxy_set_header Host 127.0.0.1;
+    proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header REMOTE-HOST $remote_addr;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_http_version 1.1;
-    # proxy_hide_header Upgrade;
-
-    add_header X-Cache $upstream_cache_status;
-}
-#PROXY-END/
-
-#PROXY-START /admin for web-ui
-location ^~ /admin
-{
-    proxy_pass http://127.0.0.1:8080/admin;
-    proxy_set_header Host 127.0.0.1;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header REMOTE-HOST $remote_addr;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/README_CN.md
+++ b/README_CN.md
@@ -117,7 +117,7 @@ cd backend && go build
 
 3. 编译前端
 ```shell
-cd soybean-admin && pnpm i && pnpm build
+cd soybean-admin && pnpm i && pnpm build --outDir dist/admin
 ```
 
 ### 运行
@@ -149,30 +149,14 @@ rustdesk-api-server-pro.exe start
 
 下面是`nginx`反向代理的参考配置：
 ```nginx
-#PROXY-START /api for rustdesk client
-location ^~ /api
+#PROXY-START
+location ~ ^/(api|admin)
 {
     proxy_pass http://127.0.0.1:8080;
-    proxy_set_header Host 127.0.0.1;
+    proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header REMOTE-HOST $remote_addr;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_http_version 1.1;
-    # proxy_hide_header Upgrade;
-
-    add_header X-Cache $upstream_cache_status;
-}
-#PROXY-END/
-
-#PROXY-START /admin for web-ui
-location ^~ /admin
-{
-    proxy_pass http://127.0.0.1:8080/admin;
-    proxy_set_header Host 127.0.0.1;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header REMOTE-HOST $remote_addr;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;

--- a/soybean-admin/.env
+++ b/soybean-admin/.env
@@ -1,4 +1,4 @@
-VITE_BASE_URL=/
+VITE_BASE_URL=/admin/
 
 VITE_APP_TITLE=Rustdesk Api Server Pro
 


### PR DESCRIPTION
Currently the front-end is served under `/`. That doesn't allow to proxy pass requests to `/admin` only and all the traffic has to be passed to the service.

This PR changes that moving the front-end to be served under `/admin` similarly to how the back-end is served under `/api`.

Some references of the options used to achieve this:

https://vite.dev/config/shared-options#base
https://v2.vitejs.dev/config/#build-outdir

This is obviously following our exchange on https://github.com/lantongxue/rustdesk-api-server-pro/issues/15

Of course you can close this PR without merging it if you don't think that's a change you want to make. I opened it to make things easier for you if you did.